### PR TITLE
Access WebSocket server through IP address declared in local development environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ app.*.symbols
 
 # Obfuscation related
 app.*.map.json
+
+# Environment variables
+.env

--- a/lib/gameLauncher.dart
+++ b/lib/gameLauncher.dart
@@ -1,6 +1,7 @@
 import 'package:flame_forge2d/flame_forge2d.dart';
-import 'serverHandler.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
+import 'serverHandler.dart';
 import 'mainMenu.dart';
 import 'mainGame.dart';
 import 'gameOverlay.dart';
@@ -18,12 +19,6 @@ class GameLauncher extends StatefulWidget {
 }
 
 class GameLauncherState extends State<GameLauncher> {
-  // IP Addresses
-  String androidIP = "ws://10.0.2.2:3000";
-  String orlandoIP = "ws://192.168.1.183:3000";
-  String winterGardenIP_2G = "ws://192.168.1.8:3000";
-  String winterGardenIP_5G = "ws://192.168.1.4:3000";
-
   // UI Variables
   String state = "out";
   int remainingPlayers = 0;
@@ -37,7 +32,7 @@ class GameLauncherState extends State<GameLauncher> {
   @override
   void initState() {
     super.initState();
-    channel = IOWebSocketChannel.connect(winterGardenIP_5G);
+    channel = IOWebSocketChannel.connect(DotEnv().env['WSS_IP']);
     serverHandler = ServerHandler(launcher: this);
     game = MainGame(launcher: this, viewportSize: widget.viewportSize);
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import "package:flame/util.dart";
 import 'package:flutter/material.dart' hide Image;
 import 'package:flutter/services.dart';
 import 'package:gameOff2020/gameLauncher.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -12,6 +13,8 @@ void main() async {
   await flameUtil.setLandscape();
   await SystemChrome.setEnabledSystemUIOverlays([]);
   Vector2 viewportSize = await flameUtil.initialDimensions();
+
+  await DotEnv().load('.env');
 
   runApp(GameLauncher(viewportSize));
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -90,6 +90,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_dotenv:
+    dependency: "direct dev"
+    description:
+      name: flutter_dotenv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_dotenv: ^2.1.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
@@ -73,6 +74,7 @@ flutter:
 
   # To add assets to your application, add an assets section, like this:
   assets:
+    - .env
     - assets/images/joystickBase.png
     - assets/images/joystickKnob.png
     - assets/images/spaceship.png


### PR DESCRIPTION
This makes our lives a little easier by not forcing us to have to manually change the WebSocket server's IP address every time one of us pulls the other's changes. You'll need to create a file called *.env* in our project's root *(this is ignored by git)*:
![image](https://user-images.githubusercontent.com/38385026/100595662-838a6f80-32fb-11eb-8fb4-db3aca6269a9.png)

Add the following to it:
```
WSS_IP=ws://10.0.2.2:3000

ANDROID_IP=ws://10.0.2.2:3000
OTHER_MACHINE_IP=ws://192.168.1.183:3000
YET_ANOTHER_MACHINE_IP=ws://192.168.1.8:3000
AND_ANOTHER_MACHINE_IP=ws://192.168.1.4:3000
```
Only `WSS_IP` will actually be used, the others are just for your reference and you can replace `WSS_IP`'s value with theirs when you need to use them. In *gameLauncher.dart*, we now state the server's IP address like so:
`channel = IOWebSocketChannel.connect(DotEnv().env['WSS_IP']);`

🚨 If you need to use a different address, don't change it directly in the code. Just update `WSS_IP`'s value in *.env* 🚨  
